### PR TITLE
feat: convert type to lower in save history

### DIFF
--- a/apps/management/views.py
+++ b/apps/management/views.py
@@ -178,7 +178,7 @@ class UpdateEntryView(BaseView):
 
     def create_history(self, forum_id: int, data: dict):
         new_data = data.copy()
-        type = new_data.pop("type", "topic")
+        type = new_data.pop("type", "topic").lower()
 
         return EntryHistoryService.create(
             entry_id=forum_id,


### PR DESCRIPTION
This pull request includes a small change to the `apps/management/views.py` file. The change ensures that the `type` field in the `create_history` method is converted to lowercase before being processed.